### PR TITLE
Fixes deepcopy error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     install_requires=[
         "autograd",
         "dataclasses; python_version<'3.7'",
-        "gym==0.23.0",
+        "gym==0.21.0",
         "mesa<=0.8.7",
         "numpy",
         "networkx",


### PR DESCRIPTION
Sorry, I've introduced this error fixing the version to 0.23.
At the time I've only ran the tests, but our current test system doesn't account for integration systems so I didn't catch this one until I ran an environment.
I got an error with `ode_env` trying to deepcopy the environment. It was saying a generator item cannot be deep-copied (which is true), it seems before 0.22 an object wasn't a generator and after it was.
So setting gym to 0.21 fixes this.